### PR TITLE
filters added

### DIFF
--- a/MovieGPT-api/src/main/java/lt/techin/group/project/security/JwtAuthenticationFilter.java
+++ b/MovieGPT-api/src/main/java/lt/techin/group/project/security/JwtAuthenticationFilter.java
@@ -29,9 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         boolean isSwaggerRequest = path.startsWith("/swagger-ui/") || path.startsWith("/v3/api-docs") ||
                 path.equals("/swagger-ui.html") || path.startsWith("/auth/");
         boolean isOptionsRequest = "OPTIONS".equalsIgnoreCase(request.getMethod());
-        boolean isGenreRequest = path.startsWith("/v1/media");
-        boolean isMediaRequest = path.startsWith("/v1/genres");
-        return isSwaggerRequest || isOptionsRequest || isGenreRequest || isMediaRequest;
+        return isSwaggerRequest || isOptionsRequest;
     }
 
 

--- a/MovieGPT-api/src/main/java/lt/techin/group/project/security/SecurityConfig.java
+++ b/MovieGPT-api/src/main/java/lt/techin/group/project/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -29,6 +30,10 @@ public class SecurityConfig {
     private JwtAuthenticationFilter jwtAuthenticationFilter;
     private UserDetailsServiceImpl userDetailsService;
 
+    public static final String GENRES = "v1/genres";
+    public static final String MEDIA = "v1/media";
+    public static final String ROLE_ADMIN = "ROLE_ADMIN";
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -36,6 +41,13 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
+                                .requestMatchers(HttpMethod.GET, GENRES + "/**", MEDIA + "/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, GENRES).hasAuthority(ROLE_ADMIN)
+                                .requestMatchers(HttpMethod.DELETE, GENRES).hasAuthority(ROLE_ADMIN)
+                                .requestMatchers(HttpMethod.PUT, GENRES).hasAuthority(ROLE_ADMIN)
+                                .requestMatchers(HttpMethod.POST, MEDIA).hasAuthority(ROLE_ADMIN)
+                                .requestMatchers(HttpMethod.DELETE, MEDIA).hasAuthority(ROLE_ADMIN)
+                                .requestMatchers(HttpMethod.PUT, MEDIA).hasAuthority(ROLE_ADMIN)
                                 .requestMatchers("/auth/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/MovieGPT-api/src/main/java/lt/techin/group/project/security/SecurityConfig.java
+++ b/MovieGPT-api/src/main/java/lt/techin/group/project/security/SecurityConfig.java
@@ -30,8 +30,8 @@ public class SecurityConfig {
     private JwtAuthenticationFilter jwtAuthenticationFilter;
     private UserDetailsServiceImpl userDetailsService;
 
-    public static final String GENRES = "v1/genres";
-    public static final String MEDIA = "v1/media";
+    public static final String GENRES = "v1/genres/**";
+    public static final String MEDIA = "v1/media/**";
     public static final String ROLE_ADMIN = "ROLE_ADMIN";
 
     @Bean
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers(HttpMethod.GET, GENRES + "/**", MEDIA + "/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, GENRES, MEDIA).permitAll()
                                 .requestMatchers(HttpMethod.POST, GENRES).hasAuthority(ROLE_ADMIN)
                                 .requestMatchers(HttpMethod.DELETE, GENRES).hasAuthority(ROLE_ADMIN)
                                 .requestMatchers(HttpMethod.PUT, GENRES).hasAuthority(ROLE_ADMIN)


### PR DESCRIPTION
Added a few filters for different authorities:
1. .requestMatchers(HttpMethod.GET, GENRES + "/**", MEDIA + "/**").permitAll() -- allows anyone to GET movies and genres. Hopefully useful to front-end
2.  .requestMatchers(HttpMethod.POST, GENRES).hasAuthority(ROLE_ADMIN) -- and similar is so only ADMIN can POST, DELETE, PUT movies and genres.
3. Removed things from shouldNotFilter -- that was a bad idea to begin with.